### PR TITLE
ci: add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Sync dependencies
+        run: uv sync --dev
+
+      - name: Run test suite
+        run: uv run pytest

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # lol-tools
 
+[![CI](https://github.com/kumewata/lol-tools/actions/workflows/ci.yml/badge.svg)](https://github.com/kumewata/lol-tools/actions/workflows/ci.yml)
+
 League of Legends の試合データ分析と動画分析を、1つの CLI から扱うツール集。
 
 ## このリポジトリでできること


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that runs the test suite on pushes to main and on pull requests
- install Python 3.12 and project dependencies with uv before running pytest
- add a CI status badge to the README

## Testing
- uv run pytest
