### PR TITLE
fix: resolve lol review template from actual report file

### DIFF
--- a/packages/lol_review/src/lol_review/report.py
+++ b/packages/lol_review/src/lol_review/report.py
@@ -17,7 +17,12 @@ from lol_review.models import AnalysisResult
 _PACKAGE_ROOT = Path(__file__).parent.parent.parent
 # Installed wheel: templates are included alongside the package
 _INSTALLED_TEMPLATE_DIR = Path(__file__).parent / "templates"
-TEMPLATE_DIR = _INSTALLED_TEMPLATE_DIR if _INSTALLED_TEMPLATE_DIR.is_dir() else _PACKAGE_ROOT / "templates"
+_INSTALLED_REPORT_TEMPLATE = _INSTALLED_TEMPLATE_DIR / "report.html"
+TEMPLATE_DIR = (
+    _INSTALLED_TEMPLATE_DIR
+    if _INSTALLED_REPORT_TEMPLATE.is_file()
+    else _PACKAGE_ROOT / "templates"
+)
 OUTPUT_DIR = _PACKAGE_ROOT / "output"
 
 


### PR DESCRIPTION
## Summary
- fix `lol review` template resolution to check for the actual `report.html` file
- fall back to `packages/lol_review/templates` when the installed-package template file is missing
- verify `uv run --no-cache lol-tools review --count 1 --no-open` generates the report and `latest_findings.json`

## Testing
- `uv run --no-cache lol-tools review --count 1 --no-open`